### PR TITLE
support more call types

### DIFF
--- a/modules/function_report.py
+++ b/modules/function_report.py
@@ -77,7 +77,7 @@ class Report:
       b += 1
       for inst in block:
         i += 1
-        if inst.operation == bn.LowLevelILOperation.LLIL_CALL:
+        if inst.operation in [bn.LowLevelILOperation.LLIL_CALL, bn.LowLevelILOperation.LLIL_CALL_STACK_ADJUST, bn.LowLevelILOperation.LLIL_TAILCALL]:
           c.append(inst)
 
     # Binary fingerprint


### PR DESCRIPTION
They all still work on the dest operand, so __extract_call_target still works

TAILCALL may be debatable, but I think it's still a call to include.